### PR TITLE
Fix snekkies nft display bug

### DIFF
--- a/pages/api/openPack.js
+++ b/pages/api/openPack.js
@@ -18,8 +18,7 @@ const COLLECTIONS = {
     useBlockfrost: true
   },
   'snekkies': {
-    // Updated to correct Snekkies policy ID (matches UI and collection)
-    policyId: 'b1d156f83ef3a68d9a82bd4a8a7c1e5edbabb200f9bac3e093d9e25d',
+    policyId: 'b558ea5ecfa2a6e9701dab150248e94104402f789c090426eb60eb60',
     blockedNumbers: [],
     name: 'Snekkies',
     maxNumber: 7777,


### PR DESCRIPTION
Fix Snekkies NFT display by correcting policy ID and improving image URL extraction to prefer front images.

The previous implementation used an incorrect policy ID for Snekkies, and the image extraction logic often selected "back cover" images or generated malformed IPFS URLs, causing the frontend to display a fallback image instead of the actual NFT. This PR addresses both issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-e3eacc07-5d64-436c-9e70-a19067fcc132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e3eacc07-5d64-436c-9e70-a19067fcc132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

